### PR TITLE
Added hardcoded Postcodes dictionary and added postcodes to the output

### DIFF
--- a/RefugeNlChecker/Models.cs
+++ b/RefugeNlChecker/Models.cs
@@ -1,5 +1,5 @@
 ﻿namespace RefugeNlChecker;
-
+#pragma warning disable CS8618
 public class AppointmentOptions
 {
     public string appointment { get; set; }
@@ -61,3 +61,4 @@ public class Response
         return GetHashCode() == obj?.GetHashCode();
     }
 }
+#pragma warning restore CS8618


### PR DESCRIPTION
I find it important to also be able to show the postcode in the output. Sometimes from what I've seen the site might be limiting the results based on what (personal) postcode the person is entering when searching for places, so let's give the people the opportunity to immediately get a postcode they can use on the website when searching for the appointment.